### PR TITLE
Teaser update

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>The Chiral Cartographer — Coming Soon</title>
+  <title>The Chiral Cartographer — Coming Soon!</title>
   <meta name="description" content="Stick, Rope, Rail, & Road — a fan-made atlas for Death Stranding 2 builders.">
   <meta property="og:title" content="The Chiral Cartographer — Coming Soon" />
   <meta property="og:description" content="Forge your paths, plan your runs, and connect the world — one strand at a time." />
@@ -24,7 +24,7 @@
   </style>
 </head>
 <body class="bg-neutral-950 text-neutral-100">
-  <div class="bg-red-600 text-white text-center font-extrabold py-3 text-2xl tracking-wide">
+  <div class="bg-indigo-700 text-white text-center font-extrabold py-3 text-2xl tracking-wide">
     ** COMING SOON! **
   </div>
   <main class="container">

--- a/index.html
+++ b/index.html
@@ -36,9 +36,18 @@
 
     <section class="grid md:grid-cols-2 gap-8 items-center">
       <div>
-        <h1 class="text-3xl md:text-5xl font-extrabold tracking-tight">The Chiral Cartographer</h1>
-        <p class="mt-2 text-lg md:text-xl opacity-90">Stick, Rope, Rail, &amp; Road</p>
-        <p class="mt-5 text-neutral-300">Forge your paths, plan your runs, and connect the world — one strand at a time.</p>
+        <div class="flex items-center gap-3">
+	  <img src="res/favicon.ico" alt="The Chiral Cartographer Logo" class="h-12 w-12 md:h-16 md:w-16 object-contain" />
+  	  <div>
+	    <h1 class="text-3xl md:text-5xl font-extrabold tracking-tight">
+	      The Chiral Cartographer
+	    </h1>
+	    <p class="mt-2 text-lg md:text-xl opacity-90">
+	      Stick, Rope, Rail, &amp; Road
+	    </p>
+	  </div>
+	</div>
+	<p class="mt-5 text-neutral-300">Forge your paths, plan your runs, and connect the world — one strand at a time.</p>
 
         <div class="mt-6 flex flex-wrap gap-3">
           <span class="pill">Plan structures!</span>

--- a/index.html
+++ b/index.html
@@ -24,6 +24,9 @@
   </style>
 </head>
 <body class="bg-neutral-950 text-neutral-100">
+  <div class="bg-red-600 text-white text-center font-extrabold py-3 text-2xl tracking-wide">
+    ** COMING SOON! **
+  </div>
   <main class="container">
     <header class="flex items-center justify-between gap-4 mb-10">
       <div class="flex items-center gap-4">
@@ -55,6 +58,7 @@
           <span class="pill">Pickups &amp; mines!</span>
           <span class="pill">Best‑yield routing!</span>
           <span class="pill">No login required!</span>
+	  <span class="pill">Community-built!</span>
         </div>
 
         <div class="mt-8 flex items-center gap-3">
@@ -64,8 +68,8 @@
       </div>
 
       <div class="card">
-        <div class="text-sm uppercase tracking-wide opacity-70 mb-2">** Coming soon! **</div>
-        <h2 class="text-xl font-semibold mb-3">A builder’s companion for Death Stranding 2</h2>
+        <h2 class="text-xl font-semibold mb-3">A Porter’s companion for Death Stranding 2!</h2>
+	<div class="mb-2 font-bold uppercase tracking-wide text-yellow-400">Planned Features:</div>
         <ul class="space-y-2 text-neutral-300">
           <li>• Add road segments, monorail lines, and other structures, then track remaining resources.</li>
           <li>• Mark unlocked preppers/outposts and mines, including upgrade levels and yields.</li>


### PR DESCRIPTION
Updated teaser page: Added logo graphic (w/o text), added a "COMING SOON" banner at the top to make the teaser page's status as a teaser page more clear, added a sixty feature blurb (class "pill") so that the features line up to a clean 3x2 on mobile, and changed the "coming soon" text mid-way on the page to now say "Planned Features". CF is now set to use "main" as the production branch, so this merge should deploy a new update to the chiralcartographer.com domain.